### PR TITLE
likely fix for strange error with gcc <= 9

### DIFF
--- a/fewbit/cpu/gelu.cc
+++ b/fewbit/cpu/gelu.cc
@@ -6,10 +6,10 @@ namespace fewbit {
 
 std::tuple<torch::Tensor, torch::Tensor> Quantize(torch::Tensor const &inputs,
                                                   torch::Tensor const &bounds) {
-#if __GNUC__ > 9
-    auto outputs = torch::gelu(inputs);
+#if TORCH_VERSION_MAJOR > 1 || TORCH_VERSION_MINOR >= 12
+    auto outputs = torch::gelu(inputs, "tanh");
 #else
-    auto outputs = torch::gelu(inputs, true);
+    auto outputs = torch::gelu(inputs);
 #endif
     auto codes = torch::searchsorted(bounds, inputs, true);
 


### PR DESCRIPTION
I have gcc 9 and the code wouldn't compile due to a different gelu() function interface; a `bool` parameter is passed for gcc <= 9.

I checked the torch source and saw a new parameter was added to gelu() in torch 12 (currently looks almost through release candidates, can be installed from the nightlies with something like `pip3 install --pre torch\<1.13 --extra-index-url https://download.pytorch.org/whl/nightly/cu113`). It was documented in the commit logs as a boolean for approximation, but it appears to be a string in the actual source.

I'm guessing this slipped by tests because gcc > 9 was used for testing.

I mutated the check to check for torch >= 1.12 instead, and change the boolean `true` to a string `"tanh"` which I think is what torch 12 expects.

The code sequence seems very strange, and I'm curious if it was made by some AI refactoring tool. I don't use one, so I'm always looking to learn if there's a good one.